### PR TITLE
Register vendor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/farsightsec/go-nmsg_sie
+
+go 1.18
+
+require (
+	github.com/farsightsec/go-nmsg v0.2.1-0.20230602182341-1a89ec71bd8b
+	google.golang.org/protobuf v1.30.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/dnstap/golang-dnstap v0.4.0 h1:KRHBoURygdGtBjDI2w4HifJfMAhhOqDuktAokaSa234=
+github.com/farsightsec/go-nmsg v0.2.1-0.20230602182341-1a89ec71bd8b h1:Ze57EgOAfDXBYMwzEsRPaubLraKi8Awv8AzEJe26cTc=
+github.com/farsightsec/go-nmsg v0.2.1-0.20230602182341-1a89ec71bd8b/go.mod h1:DmYBeMw4XxsC49A4pSibKLvbgUT4sucKiRoa4p6CPMU=
+github.com/farsightsec/golang-framestream v0.3.0 h1:/spFQHucTle/ZIPkYqrfshQqPe2VQEzesH243TjIwqA=
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/miekg/dns v1.1.31 h1:sJFOl9BgwbYAWOGEwr61FU28pqsBNdpRBnhGXtO06Oo=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
+golang.org/x/net v0.0.0-20190923162816-aa69164e4478 h1:l5EDrHhldLYb3ZRHDUhXF7Om7MvYXnkV9/iQNo1lX6g=
+golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
+google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/sie.go
+++ b/sie.go
@@ -19,6 +19,7 @@ func (p *QR) GetMsgtype() uint32         { return 3 }
 func (p *Reputation) GetMsgtype() uint32 { return 2 }
 
 func init() {
+	nmsg.RegisterVendor("sie", 2)
 	nmsg.Register(&Delay{})
 	nmsg.Register(&DnsDedupe{})
 	nmsg.Register(&DnsNX{})


### PR DESCRIPTION
Register the "sie" vendor name with the RegisterVendor API added to go-nmsg.

go.mod references the required version, and should be updated when that is released.